### PR TITLE
Fix linking not working with macOS

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -7,7 +7,7 @@
       "cflags_cc!": [ "-fno-exceptions" ],
       "libraries": [
            '-lrgblibcffi',
-           '-Wl,-rpath=<(module_root_dir)/rgb-lib/bindings/c-ffi/target/debug/',
+           '-Wl,-rpath,<(module_root_dir)/rgb-lib/bindings/c-ffi/target/debug/',
        ],
       "library_dirs": [
           "<(module_root_dir)/rgb-lib/bindings/c-ffi/target/debug/",


### PR DESCRIPTION
I'm using macOS environment and when I try to install the library I get this error on build part:
```
ld: unknown options: -rpath=path/to/target/debug/
```

This is because mac relies on clang compiler which doesn't support the current syntax to pass `rpath` option. See Stack Overflow for more details https://stackoverflow.com/questions/26472590/ld-unknown-option-rpath-libs-linking-error-while-building-openframework

This PR fixes it... Don't know if it won't break on GNU though 😅 I let you check and I'll iterate if it's breaking