### PR TITLE
Fix getBtcBalance wrapper response

### DIFF
--- a/example.js
+++ b/example.js
@@ -54,7 +54,7 @@ function initWallet(vanillaKeychain) {
     console.log("Wallet created");
 
     let btcBalance = wallet.getBtcBalance(null, true);
-    console.log("BTC balance: " + btcBalance);
+    console.log("BTC balance: " + JSON.stringify(btcBalance));
 
     let address = wallet.getAddress();
     console.log("Address: " + address);
@@ -66,7 +66,7 @@ function initWallet(vanillaKeychain) {
     console.log("Wallet went online");
 
     btcBalance = wallet.getBtcBalance(online, false);
-    console.log("BTC balance: " + btcBalance);
+    console.log("BTC balance: " + JSON.stringify(btcBalance));
 
     let created = wallet.createUtxos(online, false, "25", null, "1.0", false);
     console.log("Created " + created + " UTXOs");

--- a/wrapper.js
+++ b/wrapper.js
@@ -293,7 +293,9 @@ exports.Wallet = class Wallet {
             skipSync: "boolean",
         };
         validateTypes(params, expectedTypes);
-        return lib.rgblib_get_btc_balance(this.wallet, online, skipSync);
+        return JSON.parse(
+            lib.rgblib_get_btc_balance(this.wallet, online, skipSync),
+        );
     }
 
     getFeeEstimation(online, blocks) {


### PR DESCRIPTION
The `wallet.getBtcBalance` method returns the data as a string instead of an object. All similar methods do a `JSON.parse` before to return an object.
This PR resolves the inconsistency by adding the missing parse