### PR TITLE
Implement promises library with non-blocking methods

### DIFF
--- a/promises/index.js
+++ b/promises/index.js
@@ -1,0 +1,66 @@
+const path = require("path");
+const { Worker } = require("worker_threads");
+
+let workerPromise;
+async function initWorker() {
+    if (workerPromise) return workerPromise;
+    const worker = new Worker(path.join(__dirname, "worker.js"));
+    workerPromise = new Promise((resolve) => {
+        function onReady() {
+            worker.off("message", onReady);
+            let pendingPromises = {};
+            worker.on("message", ({ id, res, err }) => {
+                if (err) pendingPromises[id].reject(err);
+                else pendingPromises[id].resolve(res);
+                delete pendingPromises[id];
+            });
+            const wrappedWorker = {
+                sendMessage: ({ isClass, self, method, args }) => {
+                    const id = Math.random().toString(36).substring(2);
+                    return new Promise((resolve, reject) => {
+                        pendingPromises[id] = { resolve, reject };
+                        worker.postMessage({ id, isClass, self, method, args });
+                    });
+                },
+            };
+            resolve(wrappedWorker);
+        }
+        worker.on("message", onReady);
+    });
+
+    return workerPromise;
+}
+
+function proxify(worker, res) {
+    return new Proxy(res, {
+        get(obj, method) {
+            if (method === "then" || method === "catch" || method === "finally")
+                return obj[method];
+            return (...args) => worker.sendMessage({ self: obj, method, args });
+        },
+    });
+}
+
+function wrapClass(className) {
+    return async (...args) => {
+        const worker = await initWorker();
+        const res = await worker.sendMessage({
+            isClass: true,
+            method: className,
+            args,
+        });
+        return proxify(worker, res);
+    };
+}
+
+function wrapMethod(methodName) {
+    return async (...args) => {
+        const worker = await initWorker();
+        return worker.sendMessage({ method: methodName, args });
+    };
+}
+
+exports.Wallet = wrapClass("Wallet");
+exports.dropOnline = wrapMethod("dropOnline");
+exports.generateKeys = wrapMethod("generateKeys");
+exports.restoreKeys = wrapMethod("restoreKeys");

--- a/promises/index.js
+++ b/promises/index.js
@@ -22,6 +22,7 @@ async function initWorker() {
                         worker.postMessage({ id, isClass, self, method, args });
                     });
                 },
+                terminate: () => worker.terminate(),
             };
             resolve(wrappedWorker);
         }
@@ -29,6 +30,14 @@ async function initWorker() {
     });
 
     return workerPromise;
+}
+
+async function clearResources() {
+    if (workerPromise) {
+        const worker = await workerPromise;
+        workerPromise = null;
+        await worker.terminate();
+    }
 }
 
 function proxify(worker, res) {
@@ -64,3 +73,4 @@ exports.Wallet = wrapClass("Wallet");
 exports.dropOnline = wrapMethod("dropOnline");
 exports.generateKeys = wrapMethod("generateKeys");
 exports.restoreKeys = wrapMethod("restoreKeys");
+exports.clearResources = clearResources;

--- a/promises/worker.js
+++ b/promises/worker.js
@@ -1,0 +1,36 @@
+const { parentPort } = require("worker_threads");
+const wrapper = require("../wrapper");
+
+const registry = {};
+parentPort.on("message", ({ id, isClass, self, method, args }) => {
+    try {
+        if (self) self = getArgValue(self);
+        else self = wrapper;
+        if (typeof self[method] !== "function") {
+            throw new Error(
+                `${self[method]} is not a function (calling ${method})`,
+            );
+        }
+
+        let res;
+        if (isClass) res = new self[method](...args.map(getArgValue));
+        else res = self[method](...args.map(getArgValue));
+        try {
+            parentPort.postMessage({ id, res });
+        } catch (e) {
+            if (e.name === "DataCloneError") {
+                registry[id] = res;
+                parentPort.postMessage({ id, res: { _id: id } });
+            } else {
+                throw e;
+            }
+        }
+    } catch (err) {
+        parentPort.postMessage({ id, err });
+    }
+});
+parentPort.postMessage(null);
+
+function getArgValue(a) {
+    return registry[a?._id] || a;
+}


### PR DESCRIPTION
This PR adds an alternate version of the wrapper library that supports async operations.
The issue with the current wrapper is that each method is blocking, which is generally an anti-pattern in JS. Concretely it means that when you call a method that takes multiple seconds to complete (like refreshing your assetsà, the whole app will freeze for multiple seconds and you can't do any other operation in between.
I added another module `rgb-lib/promises` where all methods perform the tasks asynchronously instead and return a promise. It uses [worker threads](https://nodejs.org/api/worker_threads.html) under the hood.

Usage:
```
const { Wallet, restoreKeys } = require("rgb-lib/promises");
const { WalletData, BitcoinNetwork } = require("rgb-lib");

async function main() {
  const { accountXpub } = await restoreKeys(BitcoinNetwork.Testnet, mnemonic);

  const wallet = await Wallet(new WalletData({
    pubkey: accountXpub,
    // ...
  }));

  const online = await wallet.goOnline(true, "ssl://electrum.iriswallet.com:50013");
  const balance = await wallet.getBtcBalance(online, true);
  
  // etc
}
```