### PR TITLE
Add Testnet4 to BitcoinNetwork definition

### DIFF
--- a/template/wrapper.js
+++ b/template/wrapper.js
@@ -155,6 +155,7 @@ exports.AssetSchema = AssetSchema = {
 exports.BitcoinNetwork = BitcoinNetwork = {
     Mainnet: "Mainnet",
     Testnet: "Testnet",
+    Testnet4: "Testnet4",
     Signet: "Signet",
     Regtest: "Regtest",
 };


### PR DESCRIPTION
This PR updates the `BitcoinNetwork` to include the Testnet4 network option.